### PR TITLE
🥟 improve(cli): clearer lockfile recovery guidance for dev/start (만두킹)

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -67,11 +67,13 @@ export async function dev(options: DevOptions = {}): Promise<void> {
 
   if (action === "block") {
     console.error("🛑 서버 시작 차단: Lockfile 불일치");
-    console.error("   설정이 변경되었습니다. 의도한 변경이라면:");
+    console.error("   설정이 변경되었습니다. 의도한 변경이라면 아래 중 하나를 실행하세요:");
     console.error("   $ mandu lock");
+    console.error("   $ bunx mandu lock");
     console.error("");
     console.error("   변경 사항 확인:");
     console.error("   $ mandu lock --diff");
+    console.error("   $ bunx mandu lock --diff");
     if (lockResult) {
       console.error("");
       console.error(formatValidationResult(lockResult));
@@ -89,10 +91,12 @@ export async function dev(options: DevOptions = {}): Promise<void> {
   // Lockfile 상태 출력
   if (action === "warn") {
     console.log(`⚠️  ${formatPolicyAction(action, bypassed)}`);
+    console.log(`   ↳ lock 갱신: mandu lock  (or bunx mandu lock)`);
+    console.log(`   ↳ 변경 확인: mandu lock --diff  (or bunx mandu lock --diff)`);
   } else if (lockfile && lockResult?.valid) {
     console.log(`🔒 설정 무결성 확인됨 (${lockResult.currentHash?.slice(0, 8)})`);
   } else if (!lockfile) {
-    console.log(`💡 Lockfile 없음 - 'mandu lock'으로 생성 권장`);
+    console.log(`💡 Lockfile 없음 - 'mandu lock' 또는 'bunx mandu lock'으로 생성 권장`);
   }
 
   // .env 파일 로드

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -73,11 +73,13 @@ export async function start(options: StartOptions = {}): Promise<void> {
 
   if (action === "block") {
     console.error("🛑 서버 시작 차단: Lockfile 불일치");
-    console.error("   설정이 변경되었습니다. 의도한 변경이라면:");
+    console.error("   설정이 변경되었습니다. 의도한 변경이라면 아래 중 하나를 실행하세요:");
     console.error("   $ mandu lock");
+    console.error("   $ bunx mandu lock");
     console.error("");
     console.error("   변경 사항 확인:");
     console.error("   $ mandu lock --diff");
+    console.error("   $ bunx mandu lock --diff");
     if (lockResult) {
       console.error("");
       console.error(formatValidationResult(lockResult));
@@ -92,10 +94,12 @@ export async function start(options: StartOptions = {}): Promise<void> {
   // Lockfile 상태 출력
   if (action === "warn") {
     console.log(`⚠️  ${formatPolicyAction(action, bypassed)}`);
+    console.log(`   ↳ lock 갱신: mandu lock  (or bunx mandu lock)`);
+    console.log(`   ↳ 변경 확인: mandu lock --diff  (or bunx mandu lock --diff)`);
   } else if (lockfile && lockResult?.valid) {
     console.log(`🔒 설정 무결성 확인됨 (${lockResult.currentHash?.slice(0, 8)})`);
   } else if (!lockfile) {
-    console.log(`💡 Lockfile 없음 - 'mandu lock'으로 생성 권장`);
+    console.log(`💡 Lockfile 없음 - 'mandu lock' 또는 'bunx mandu lock'으로 생성 권장`);
   }
 
   // .env 파일 로드 (production 모드)


### PR DESCRIPTION
## 🥟 만두킹(ManduKing) 개선 제안 PR

## Summary
- lockfile mismatch 시 안내 메시지에 실행 가능한 복구 커맨드를 명확히 추가했습니다.
- `mandu`가 PATH에 없을 수 있는 환경을 고려해 `bunx mandu ...` 대안을 함께 표시합니다.

## Changes
- `dev` / `start`에서 block 상황 메시지 개선
  - `mandu lock`
  - `bunx mandu lock`
  - `mandu lock --diff`
  - `bunx mandu lock --diff`
- warn 상황에서도 즉시 따라할 수 있는 가이드를 추가
- lockfile 미존재 안내 문구 개선 (`mandu lock` 또는 `bunx mandu lock`)

## Why
현장에서 `mandu dev`를 바로 쓰는 흐름에서 lockfile 경고가 발생하면,
사용자가 다음 액션을 즉시 이해하지 못해 진입 마찰이 커집니다.
특히 PATH/실행환경 차이로 `mandu` 직접 호출이 안 되는 경우가 있어,
`bunx mandu` 대안을 공식 안내하는 것이 안전합니다.

## Validation
- `bun test packages/cli/tests`

Closes #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced user guidance for lockfile management, providing instructions for both standard and alternative command variants when addressing outdated, invalid, or missing lockfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->