### PR TITLE
🥟 improve(init): clarify CLI path guidance for mandu vs bunx (만두킹)

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -272,6 +272,9 @@ export async function init(options: InitOptions = {}): Promise<boolean> {
   console.log(`   cd ${projectName}`);
   console.log(`   bun install`);
   console.log(`   bun run dev`);
+  console.log(`\n💡 CLI 실행 참고 (환경별):`);
+  console.log(`   bun run dev        # 권장 (로컬 스크립트)`);
+  console.log(`   bunx mandu dev     # PATH에 mandu가 없을 때 대안`);
   console.log(`\n📂 파일 구조:`);
   console.log(`   app/layout.tsx    → 루트 레이아웃`);
   console.log(`   app/page.tsx      → http://localhost:3000/`);


### PR DESCRIPTION
## 🥟 만두킹(ManduKing) 개선 제안 PR

## Summary
`mandu init` 완료 메시지에 CLI 실행 경로 안내를 명확히 추가했습니다.

## Changes
- 시작 가이드에 환경별 실행 안내 추가
  - `bun run dev` (권장)
  - `bunx mandu dev` (PATH에 `mandu`가 없을 때 대안)

## Why
이슈 #32처럼 환경에 따라 `mandu` 바이너리 인식 여부가 달라질 수 있습니다.
초기 출력에서 즉시 대안을 제공하면 초심자 진입 마찰을 크게 줄일 수 있습니다.

## Validation
- `bun test packages/cli/tests`

Closes #32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CLI initialization with additional environment-specific usage guidance displayed during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->