### PR TITLE
refactor: remove magic number for init backup suffix retry

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -20,6 +20,7 @@ export interface InitOptions {
 }
 
 const ALLOWED_TEMPLATES = ["default", "realtime-chat"] as const;
+const MAX_BACKUP_SUFFIX_ATTEMPTS = 50;
 type AllowedTemplate = (typeof ALLOWED_TEMPLATES)[number];
 
 export function isAllowedTemplate(template: string): template is AllowedTemplate {
@@ -515,7 +516,7 @@ async function setupMcpConfig(targetDir: string): Promise<McpConfigResult> {
       if (!(await fileExists(base))) {
         return base;
       }
-      for (let i = 1; i <= 50; i++) {
+      for (let i = 1; i <= MAX_BACKUP_SUFFIX_ATTEMPTS; i++) {
         const candidate = `${basePath}.bak.${i}`;
         if (!(await fileExists(candidate))) {
           return candidate;


### PR DESCRIPTION
## Summary\n- replace hardcoded retry count in CLI init command with a named constant\n- keep existing backup filename resolution behavior unchanged\n\n## Testing\n- bun test packages/cli/tests/commands/init.test.ts\n\nCloses #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized configuration values to improve code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->