### PR TITLE
test(core): add concurrent rate-limit coverage (#54)

### DIFF
--- a/packages/core/tests/server/rate-limit.test.ts
+++ b/packages/core/tests/server/rate-limit.test.ts
@@ -77,7 +77,10 @@ describe("Server Rate Limit", () => {
   });
 
   it("동시 요청에서도 제한 개수를 초과하지 않는다", async () => {
-    registry.registerApiHandler("api/limited", async () => Response.json({ ok: true }));
+    registry.registerApiHandler("api/limited", async () => {
+      await new Promise((resolve) => setTimeout(resolve, Math.floor(Math.random() * 20)));
+      return Response.json({ ok: true });
+    });
 
     server = startServer(testManifest, {
       port: 0,


### PR DESCRIPTION
## Summary
- add a focused concurrent-request test for API rate limiting
- verify that exactly max-allowed requests succeed and overflow requests return 429 under parallel load
- keep scope tight to critical server behavior in packages/core/tests/server/rate-limit.test.ts

Closes #54