### PR TITLE
fix(demo): improve user-facing error feedback in ai-chat flow

### DIFF
--- a/demo/ai-chat/apps/web/entry.tsx
+++ b/demo/ai-chat/apps/web/entry.tsx
@@ -32,6 +32,12 @@ function hydrateIslands() {
       console.log(`[Mandu] Island hydrated: ${islandName}`);
     } catch (error) {
       console.error(`[Mandu] Failed to hydrate island: ${islandName}`, error);
+      element.innerHTML = `
+        <div style="padding:12px; border:1px solid rgba(239,68,68,0.4); background: rgba(127,29,29,0.25); color:#fecaca; border-radius:12px; font-size:14px; line-height:1.5;">
+          <strong style="display:block; margin-bottom:4px; color:#fee2e2;">⚠️ UI 로드 실패</strong>
+          <span>채팅 인터페이스를 불러오지 못했습니다. 페이지를 새로고침 후 다시 시도해주세요.</span>
+        </div>
+      `;
     }
   });
 }

--- a/demo/ai-chat/src/client/islands/chatError.test.ts
+++ b/demo/ai-chat/src/client/islands/chatError.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+import { extractErrorMessage, toUserFeedback } from './chatError';
+
+describe('chatError utilities', () => {
+  it('extracts message from Error', () => {
+    expect(extractErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('maps network errors to user-friendly feedback', () => {
+    const feedback = toUserFeedback(new Error('Failed to fetch'));
+    expect(feedback.title).toBe('네트워크 오류');
+    expect(feedback.retryable).toBe(true);
+  });
+
+  it('maps 5xx errors to server error feedback', () => {
+    const feedback = toUserFeedback(new Error('HTTP 500: Internal Server Error'));
+    expect(feedback.title).toBe('서버 오류');
+  });
+
+  it('returns generic fallback for unknown errors', () => {
+    const feedback = toUserFeedback({});
+    expect(feedback.title).toBe('처리 중 오류 발생');
+  });
+});

--- a/demo/ai-chat/src/client/islands/chatError.ts
+++ b/demo/ai-chat/src/client/islands/chatError.ts
@@ -1,0 +1,78 @@
+export interface ChatErrorFeedback {
+  title: string;
+  message: string;
+  retryable: boolean;
+}
+
+export function toUserFeedback(error: unknown): ChatErrorFeedback {
+  const message = extractErrorMessage(error);
+  const lower = message.toLowerCase();
+
+  if (lower.includes('invalid request body')) {
+    return {
+      title: '요청 형식 오류',
+      message: '요청 데이터가 올바르지 않습니다. 입력 내용을 확인 후 다시 시도해주세요.',
+      retryable: true,
+    };
+  }
+
+  if (lower.includes('network') || lower.includes('failed to fetch')) {
+    return {
+      title: '네트워크 오류',
+      message: '서버에 연결할 수 없습니다. 네트워크 상태를 확인하고 다시 시도해주세요.',
+      retryable: true,
+    };
+  }
+
+  if (lower.includes('timeout') || lower.includes('abort')) {
+    return {
+      title: '응답 지연',
+      message: '응답이 지연되고 있습니다. 잠시 후 다시 시도해주세요.',
+      retryable: true,
+    };
+  }
+
+  if (lower.includes('스트림') || lower.includes('stream')) {
+    return {
+      title: '응답 스트림 오류',
+      message: '응답을 수신하는 중 문제가 발생했습니다. 다시 시도해주세요.',
+      retryable: true,
+    };
+  }
+
+  if (lower.includes('http 4')) {
+    return {
+      title: '요청 처리 실패',
+      message: '요청을 처리할 수 없습니다. 입력 내용을 확인하고 다시 시도해주세요.',
+      retryable: true,
+    };
+  }
+
+  if (lower.includes('http 5')) {
+    return {
+      title: '서버 오류',
+      message: '일시적인 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+      retryable: true,
+    };
+  }
+
+  return {
+    title: '처리 중 오류 발생',
+    message: '요청을 처리하는 중 오류가 발생했습니다. 다시 시도해주세요.',
+    retryable: true,
+  };
+}
+
+export function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+
+  if (error && typeof error === 'object') {
+    const withMessage = error as { message?: unknown; error?: unknown; status?: unknown };
+    if (typeof withMessage.message === 'string') return withMessage.message;
+    if (typeof withMessage.error === 'string') return withMessage.error;
+    if (typeof withMessage.status === 'number') return `HTTP ${withMessage.status}`;
+  }
+
+  return 'Unknown error';
+}


### PR DESCRIPTION
## Summary
- add robust, user-friendly error mapping for chat/demo failures
- show explicit inline error banner in ChatBox (dismissible)
- improve API failure handling by surfacing HTTP status/details
- detect abnormal stream termination and empty stream responses
- provide hydration-failure fallback UI in demo island entry
- add unit tests for chat error feedback mapping

## Why
Fixes missing user feedback on chat/demo failures. Resolves #48.

## Testing
- ✅ `bun test ./demo/ai-chat/src/client/islands/chatError.test.ts`
- ⚠️ `bun test` currently has unrelated pre-existing failures in this repo/worktree (missing deps and existing failing suites), not introduced by this PR.
