### PR TITLE
perf: 메시지 렌더링 시 Date 객체 생성 최소화

### DIFF
--- a/packages/cli/templates/realtime-chat/src/client/features/chat/realtime-chat-starter.client.tsx
+++ b/packages/cli/templates/realtime-chat/src/client/features/chat/realtime-chat-starter.client.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 import { Button, Input } from "@/client/shared/ui";
 import { useRealtimeChat } from "./use-realtime-chat";
 
 export function RealtimeChatStarter() {
   const { messages, send, canSend, sending } = useRealtimeChat();
   const [text, setText] = useState("");
+  const messagesWithTime = useMemo(
+    () =>
+      messages.map((message) => ({
+        ...message,
+        displayTime: new Date(message.createdAt).toLocaleTimeString(),
+      })),
+    [messages],
+  );
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -21,7 +29,7 @@ export function RealtimeChatStarter() {
         {messages.length === 0 ? (
           <p className="text-sm text-muted-foreground">No messages yet. Start chatting.</p>
         ) : (
-          messages.map((message) => (
+          messagesWithTime.map((message) => (
             <div
               key={message.id}
               className={`max-w-[80%] rounded-lg px-3 py-2 text-sm ${
@@ -31,7 +39,7 @@ export function RealtimeChatStarter() {
               }`}
             >
               <div>{message.text}</div>
-              <div className="mt-1 text-[10px] opacity-70">{new Date(message.createdAt).toLocaleTimeString()}</div>
+              <div className="mt-1 text-[10px] opacity-70">{message.displayTime}</div>
             </div>
           ))
         )}


### PR DESCRIPTION
## 요약
- realtime-chat starter UI에서 메시지 타임스탬프 포맷을 useMemo로 캐싱
- 입력 중 재렌더마다 new Date(message.createdAt)가 반복 생성되지 않도록 최적화
- 출력 형식은 기존 toLocaleTimeString() 결과를 그대로 유지

## 배경
- Closes #52

## 테스트
- bun test packages/cli/templates/realtime-chat/tests/chat-starter.test.ts *(실패: 템플릿 경로 alias 및 @mandujs/core/runtime/server 모듈 해석 이슈 - 기존 환경 문제)*
- bunx tsc --noEmit *(실패: 저장소 전반의 기존 타입 오류 다수, 본 변경과 무관)*
