### PR TITLE
fix(a11y): Input 컴포넌트 ARIA 라벨 보강 (#47)

### DIFF
--- a/demo/test-app/components/ui/input.tsx
+++ b/demo/test-app/components/ui/input.tsx
@@ -5,10 +5,14 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, placeholder, "aria-label": ariaLabel, ...props }, ref) => {
+    const accessibleLabel = ariaLabel ?? (typeof placeholder === "string" ? placeholder : undefined);
+
     return (
       <input
         type={type}
+        placeholder={placeholder}
+        aria-label={accessibleLabel}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className

--- a/demo/todo-list-mandu/src/client/shared/ui/input.tsx
+++ b/demo/todo-list-mandu/src/client/shared/ui/input.tsx
@@ -5,10 +5,14 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, placeholder, "aria-label": ariaLabel, ...props }, ref) => {
+    const accessibleLabel = ariaLabel ?? (typeof placeholder === "string" ? placeholder : undefined);
+
     return (
       <input
         type={type}
+        placeholder={placeholder}
+        aria-label={accessibleLabel}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className

--- a/packages/cli/templates/default/src/client/shared/ui/input.tsx
+++ b/packages/cli/templates/default/src/client/shared/ui/input.tsx
@@ -5,10 +5,14 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, placeholder, "aria-label": ariaLabel, ...props }, ref) => {
+    const accessibleLabel = ariaLabel ?? (typeof placeholder === "string" ? placeholder : undefined);
+
     return (
       <input
         type={type}
+        placeholder={placeholder}
+        aria-label={accessibleLabel}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className

--- a/packages/cli/templates/realtime-chat/src/client/shared/ui/input.tsx
+++ b/packages/cli/templates/realtime-chat/src/client/shared/ui/input.tsx
@@ -5,10 +5,14 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, placeholder, "aria-label": ariaLabel, ...props }, ref) => {
+    const accessibleLabel = ariaLabel ?? (typeof placeholder === "string" ? placeholder : undefined);
+
     return (
       <input
         type={type}
+        placeholder={placeholder}
+        aria-label={accessibleLabel}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className


### PR DESCRIPTION
## 요약
- Input 컴포넌트에 `aria-label`을 명시적으로 지원했습니다.
- `aria-label`이 없고 `placeholder`가 문자열일 경우, 접근성 라벨로 fallback 하도록 보강했습니다.
- default/realtime-chat 템플릿과 데모 Input 구현을 동일하게 맞췄습니다.

## 변경 파일
- `packages/cli/templates/default/src/client/shared/ui/input.tsx`
- `packages/cli/templates/realtime-chat/src/client/shared/ui/input.tsx`
- `demo/todo-list-mandu/src/client/shared/ui/input.tsx`
- `demo/test-app/components/ui/input.tsx`

## 테스트
- ✅ `bun test packages/cli/templates/default/tests/example.test.ts packages/cli/templates/realtime-chat/tests/example.test.ts`
  - 결과: **8 passed, 0 failed**
- ℹ️ `bun test` 전체 실행 시 레포 기존 이슈로 실패가 존재함(본 변경과 무관)

## 체크리스트
- [x] 접근성 이슈(#47) 수정
- [x] 관련 Input 구현 동기화
- [x] 관련 테스트 실행 및 결과 확인
- [x] 불필요한 파일 변경 없음

Closes #47


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Input component accessibility across the application by enhancing screen reader support and text labeling, providing a better experience for users relying on assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->