### PR TITLE
docs: demo-first realtime chat validation loop (refs #77)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -506,10 +506,13 @@ my-app/
 | 명령어 | 설명 |
 |--------|------|
 | `mandu init <name>` | 새 프로젝트 생성 |
-| `mandu generate` | app/에서 매니페스트 생성 및 코드 생성 |
-| `mandu guard` | 아키텍처 검사 실행 |
-| `mandu build` | 프로덕션용 클라이언트 번들 빌드 |
-| `mandu dev` | HMR 포함 개발 서버 실행 |
+| `mandu dev` | 개발 서버 실행 (FS Routes + Guard 기본 활성화) |
+| `mandu build` | 프로덕션 빌드 |
+| `mandu start` | 프로덕션 서버 실행 |
+| `mandu check` | 통합 점검(routes + architecture + config) |
+| `mandu guard arch` | 아키텍처 검사 실행 |
+| `mandu routes list` | 현재 라우트 목록 출력 |
+| `mandu lock` | 설정 무결성용 lockfile 생성/갱신 |
 
 ### 트랜잭션 명령어
 
@@ -529,18 +532,21 @@ my-app/
 bunx @mandujs/cli init my-app
 
 # 개발 워크플로우
-bunx mandu generate             # 매니페스트 + 코드 생성
-bunx mandu guard                # 아키텍처 검사
-bunx mandu dev                  # 개발 서버 실행
+bunx mandu dev
+bunx mandu check
 
-# 프로덕션 빌드
-bunx mandu build --minify       # 최적화된 번들 빌드
+# 프로덕션
+bunx mandu build
+bunx mandu start
+
+# 설정 무결성
+bunx mandu lock
+bunx mandu lock --verify
 
 # 트랜잭션으로 안전한 변경
 bunx mandu change begin --message "사용자 API 추가"
 # ... 변경 작업 ...
-bunx mandu change commit        # 성공: 확정
-bunx mandu change rollback      # 실패: 스냅샷 복원
+bunx mandu change commit
 ```
 
 ---
@@ -1254,7 +1260,7 @@ Mandu는 자동으로 에러를 세 가지 유형으로 분류합니다:
 
 ## 로드맵
 
-### v0.10.x (현재) — 74개 기능 완료
+### v0.10.x (현재)
 
 **Core Runtime**
 - [x] 미들웨어 compose & 라이프사이클 훅

--- a/README.md
+++ b/README.md
@@ -350,11 +350,12 @@ bunx mandu build
 |---------|-------------|
 | `mandu init` | Create new project |
 | `mandu dev` | Start dev server (FS Routes + Guard auto-enabled) |
-| `mandu dev --guard` | Dev with architecture monitoring |
 | `mandu build` | Build for production |
+| `mandu start` | Start production server |
+| `mandu check` | Run integrated routes + architecture + config checks |
 | `mandu guard arch` | Run architecture check |
 | `mandu routes list` | Show all routes |
-| `mandu status` | Show project status |
+| `mandu lock` | Generate/refresh lockfile for config integrity |
 
 ---
 
@@ -708,7 +709,7 @@ mandu/
 
 ## Roadmap
 
-### v0.10.x (Current) — 74 features done
+### v0.10.x (Current)
 
 **Core Runtime**
 - [x] Middleware compose & lifecycle hooks

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -8,6 +8,9 @@
 - `docs/architecture/02_mandu_technical_architecture.md` — 기술 아키텍처 (MVP-0.1)
 - `docs/guides/01_configuration.ko.md` — 설정 가이드
 - `docs/guides/03_mandu_coding_agent_prompt_template.md` — 코딩 에이전트 프롬프트 템플릿
+- `docs/guides/05_realtime_chat_starter.md` — 공식 realtime chat starter 가이드
+- `docs/guides/06_realtime_chat_demo_validation_loop.md` — 데모 우선 검증/성장 루프
+- `docs/guides/lockfile.md` — lock/check 무결성 트러블슈팅
 - `docs/specs/04_mandu_hydration_system.md` — 하이드레이션 시스템
 - `docs/architecture/05_mandu_backend-architecture-guardrails.md` — 백엔드 가드레일
 - `docs/architecture/06_mandu_router_v5_hybrid_trie.md` — Router v5 하이브리드 트라이
@@ -58,7 +61,7 @@ export default {
 
 ---
 
-## 문서 상태 (업데이트: 2026-02-03)
+## 문서 상태 (업데이트: 2026-02-13)
 
 | 문서 | 상태 | 비고 |
 |------|------|------|
@@ -67,7 +70,10 @@ export default {
 | `docs/product/01_mandu_product_brief.md` | 수정 | MCP/CLI 목록 및 로드맵 노트 갱신 (2026-01-30) |
 | `docs/architecture/02_mandu_technical_architecture.md` | 수정 | 구현 현황/CLI/MCP 도구 반영 (2026-01-30) |
 | `docs/guides/01_configuration.ko.md` | 신규 | 설정 가이드 (2026-02-03) |
-| `docs/guides/03_mandu_coding_agent_prompt_template.md` | 수정 | CLI 명칭 정정 (2026-01-30) |
+| `docs/guides/03_mandu_coding_agent_prompt_template.md` | 수정 | CLI 명칭/예시 정합성 보강 (2026-02-13) |
+| `docs/guides/05_realtime_chat_starter.md` | 수정 | 스타터 + 데모 우선 검증 흐름 반영 (2026-02-13) |
+| `docs/guides/06_realtime_chat_demo_validation_loop.md` | 신규 | 데모 우선 프레임워크 성장 루프 (2026-02-13) |
+| `docs/guides/lockfile.md` | 수정 | lock/check 무결성 이슈 대응 절차 (2026-02-13) |
 | `docs/specs/04_mandu_hydration_system.md` | 수정 | 구현 현황/MCP 도구 반영 (2026-01-30) |
 | `docs/architecture/05_mandu_backend-architecture-guardrails.md` | 이동 | 2026-01-28 루트에서 이동 |
 | `docs/architecture/06_mandu_router_v5_hybrid_trie.md` | 수정 | 구현 상태 표시 추가 (2026-01-30) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Quick links to project docs:
 - `docs/guides/01_configuration.md` — Configuration guide
 - `docs/guides/03_mandu_coding_agent_prompt_template.md` — Coding agent prompt template
 - `docs/guides/05_realtime_chat_starter.md` — Official realtime chat starter template guide
+- `docs/guides/06_realtime_chat_demo_validation_loop.md` — Demo-first framework validation loop
 - `docs/specs/04_mandu_hydration_system.md` — Hydration system spec
 - `docs/specs/05_fs_routes_system.md` — FS Routes system spec
 - `docs/specs/06_mandu_guard.md` — Mandu Guard architecture spec
@@ -62,18 +63,21 @@ export default {
 
 ---
 
-## Document Status (Updated 2026-02-03)
+## Document Status (Updated 2026-02-13)
 
 | Doc | Status | Note |
 |-----|--------|------|
 | `docs/api/api-reference.md` | updated | SEO API 추가 (2026-02-02) |
 | `docs/api/api-reference.ko.md` | updated | Client API 추가 (2026-01-30) |
-| `docs/status.md` | updated | SEO 섹션 추가 (65 features) (2026-02-02) |
+| `docs/status.md` | updated | Current implementation matrix synced (2026-02-13) |
 | `docs/specs/07_seo_module.md` | new | SEO 모듈 스펙 (2026-02-02) |
 | `docs/product/01_mandu_product_brief.md` | updated | MCP/CLI 목록 및 로드맵 노트 갱신 (2026-01-30) |
 | `docs/architecture/02_mandu_technical_architecture.md` | updated | 구현 현황/CLI/MCP 도구 반영 (2026-01-30) |
 | `docs/guides/01_configuration.md` | new | Configuration guide (2026-02-03) |
-| `docs/guides/03_mandu_coding_agent_prompt_template.md` | updated | CLI 명칭 정정 (2026-01-30) |
+| `docs/guides/03_mandu_coding_agent_prompt_template.md` | updated | CLI naming aligned (2026-02-13) |
+| `docs/guides/05_realtime_chat_starter.md` | updated | Starter + demo-first validation flow updated (2026-02-13) |
+| `docs/guides/06_realtime_chat_demo_validation_loop.md` | new | Demo-first framework growth loop (2026-02-13) |
+| `docs/guides/lockfile.md` | updated | lock/check integrity troubleshooting (2026-02-13) |
 | `docs/specs/04_mandu_hydration_system.md` | updated | 구현 현황/MCP 도구 반영 (2026-01-30) |
 | `docs/specs/05_fs_routes_system.md` | updated | Config note added (2026-02-03) |
 | `docs/specs/06_mandu_guard.md` | updated | Config example aligned (2026-02-03) |

--- a/docs/guides/06_realtime_chat_demo_validation_loop.md
+++ b/docs/guides/06_realtime_chat_demo_validation_loop.md
@@ -1,0 +1,69 @@
+# Realtime Chat Demo Validation Loop (Demo-First)
+
+Mandu framework changes should be validated through the realtime chat demo first, then promoted into framework fixes/features.
+
+## Why this loop exists
+
+- Prevent speculative framework changes without user-facing evidence
+- Keep architecture integrity (reuse-first, no duplication, guard compatibility)
+- Make framework growth traceable from concrete demo scenarios
+
+## Loop steps
+
+1. **Reproduce or add demo scenario first**
+   - Use `mandu-chat-demo` as the primary proving ground
+   - Capture exact command, request path, and observed result
+
+2. **Extract framework requirement**
+   - Identify what is missing in core/cli/template
+   - Label as: bug, safety gap, DX gap, architecture mismatch
+
+3. **Philosophy alignment check**
+   - Integrity: does this preserve config/runtime invariants?
+   - Architecture: does it keep boundaries clean?
+   - Reuse-first: can existing utilities be used?
+   - Duplication-zero: does it remove or avoid repeated logic?
+
+4. **Implement smallest framework change**
+   - Minimal diff first
+   - Include regression test when possible
+
+5. **Round-trip verification**
+   - Re-link/use latest package in demo
+   - Run `lock`, `dev`, `check`, and critical API scenario
+
+6. **Promote with evidence**
+   - Issue/PR must include:
+     - Demo reproduction logs
+     - Philosophy alignment notes
+     - Post-fix demo verification logs
+
+## Recommended verification checklist
+
+- [ ] `bunx @mandujs/cli lock`
+- [ ] `bunx @mandujs/cli check`
+- [ ] Demo dev boot succeeds
+- [ ] `/api/health` and one chat API succeed
+- [ ] No new architecture violations
+- [ ] No new duplicate logic introduced
+
+## PR template snippet (recommended)
+
+```md
+## Demo-first evidence
+- Scenario:
+- Repro command:
+- Before:
+- After:
+
+## Mandu philosophy alignment
+- Integrity:
+- Architecture:
+- Reuse-first:
+- Duplication-zero:
+```
+
+## Notes
+
+- If a change cannot be justified by a demo scenario, defer it.
+- Prefer incremental PRs over large mixed-purpose refactors.

--- a/docs/guides/lockfile.md
+++ b/docs/guides/lockfile.md
@@ -13,15 +13,17 @@ Mandu Lockfile은 `mandu.config`의 **결정론적 해시**를 저장하여 설�
 ## 빠른 시작
 
 ```bash
-# Lockfile 생성/갱신
-mandu lock
+# 프로젝트 로컬 CLI로 실행(권장)
+bunx @mandujs/cli lock
 
 # 설정 무결성 검증
-mandu lock --verify
+bunx @mandujs/cli lock --verify
 
 # 변경사항 확인
-mandu lock --diff
+bunx @mandujs/cli lock --diff
 ```
+
+> 로컬에 구버전 `mandu` 바이너리가 설치된 경우, `bunx @mandujs/cli ...`로 실행해 버전 불일치를 피하세요.
 
 ## 작동 원리
 
@@ -39,7 +41,7 @@ const hash = computeConfigHash(config);
 ```json
 {
   "schemaVersion": 1,
-  "manduVersion": "0.9.46",
+  "manduVersion": "0.10.x",
   "configHash": "a1b2c3d4e5f67890",
   "generatedAt": "2024-01-15T10:30:00.000Z",
   "mcpServers": {
@@ -89,7 +91,7 @@ mandu lock --verify
 mandu lock --verify --mode=ci
 
 # CI/CD에서 사용
-mandu lock --verify --json
+mandu lock --verify --mode=ci
 ```
 
 출력 예시:
@@ -136,8 +138,6 @@ mandu lock --diff --show-secrets
 | `--show-secrets` | 민감정보 출력 허용 |
 | `--include-snapshot` | 설정 스냅샷 포함 |
 | `--mode=<mode>` | 검증 모드 지정 |
-| `--quiet, -q` | 조용한 출력 |
-| `--json` | JSON 형식 출력 |
 
 ## 워크플로우
 


### PR DESCRIPTION
## Demo-first evidence (reproduction/verification logs)
- Scenario: `mandu-chat-demo` reconnect-safe catch-up (`sinceId`) requirement
- Repro command:
  - `cd mandu-chat-demo && bun test tests/chat-catchup.test.ts`
- Verification output:
  - `2 pass, 0 fail` (reconnect catch-up + fallback snapshot)

## Framework requirement extracted from demo
- Need explicit, repeatable process that forces: **demo scenario first -> framework requirement extraction -> philosophy gate -> issue/PR evidence**
- Without this loop, reconnect/catch-up style requirements can drift into app-level duplicated implementations.

## Changes in this PR
- Add `docs/guides/06_realtime_chat_demo_validation_loop.md` (new)
- Align docs indexes to include the new guide
- Update lockfile guide to avoid CLI version mismatch pitfalls and align with current lock/check usage
- Sync README command tables to current CLI contract (`dev/build/start/check/guard arch/routes list/lock`)

## Mandu philosophy alignment
- **Integrity**: lock/check + verification checklist keeps config/runtime integrity explicit
- **Architecture consistency**: codifies one shared growth path instead of ad-hoc per-app decisions
- **Reuse-first**: promotes framework-level extraction from demo patterns
- **No-duplication**: prevents repeated reconnect/catch-up policy writeups across apps

## Notes
- This is intentionally docs/process scoped (not a speculative runtime refactor).
- Runtime/API implementation should continue as separate focused PRs backed by demo logs.
