### PR TITLE
docs: add TypeScript Ultimate skill pack to Mandu

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Quick links to project docs:
 - `docs/guides/03_mandu_coding_agent_prompt_template.md` — Coding agent prompt template
 - `docs/guides/05_realtime_chat_starter.md` — Official realtime chat starter template guide
 - `docs/guides/06_realtime_chat_demo_validation_loop.md` — Demo-first framework validation loop
+- `docs/skills/README.md` — Curated engineering skill packs (TypeScript Ultimate)
 - `docs/specs/04_mandu_hydration_system.md` — Hydration system spec
 - `docs/specs/05_fs_routes_system.md` — FS Routes system spec
 - `docs/specs/06_mandu_guard.md` — Mandu Guard architecture spec

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,3 @@
+# Skills
+
+- [TypeScript Ultimate](./typescript-ultimate/SKILL.md)

--- a/docs/skills/typescript-ultimate/SKILL.md
+++ b/docs/skills/typescript-ultimate/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: typescript-ultimate
+description: End-to-end TypeScript engineering skill for designing, implementing, reviewing, and refactoring production-grade TS codebases. Use when tasks involve TypeScript architecture, advanced typing, strict safety, API/schema typing, React/Node/Nest/Express/Fastify patterns, testing, linting, migration, or code review in .ts/.tsx projects.
+---
+
+# TypeScript Ultimate
+
+Execute TypeScript work with maximum safety, clarity, and maintainability.
+
+## Workflow
+
+1. Identify context first
+   - Determine runtime: Node / Browser / React / Next / Nest / Express / Fastify / Deno / RN.
+   - Determine strictness target: incremental vs strict-by-default.
+   - Determine risk class: API contract, persistence, auth, payments, migrations are high-risk.
+
+2. Lock quality baseline before coding
+   - Apply strict compiler profile from `references/01-compiler-and-quality-baseline.md`.
+   - Apply lint and ordering rules from `references/07-code-review-and-standards.md`.
+   - Define typed boundaries for IO and external systems.
+
+3. Model domain types first
+   - Design discriminated unions for state and protocol variants.
+   - Use utility/mapped/conditional/template-literal types where they reduce duplication.
+   - Keep types readable; split deeply complex helpers into named aliases.
+
+4. Implement with type-safe boundaries
+   - Parse unknown inputs to validated domain types.
+   - Keep `any` out of core paths.
+   - Encode API request/response contracts in types.
+
+5. Verify behavior + type contracts
+   - Add runtime tests + type tests (`tsc --noEmit`, or expect-type style checks).
+   - Add edge-case checks for nullability, narrowing, and exhaustive handling.
+
+6. Review against production checklist
+   - Use `references/07-code-review-and-standards.md` review rubric.
+   - Prefer smallest safe change that improves type confidence.
+
+## Mandatory Rules
+
+- Prefer `unknown` over `any`.
+- Prefer narrowing/type guards over assertions (`as`).
+- Use discriminated unions for state machines and branching models.
+- Keep imports organized and type-only imports explicit (`import type`).
+- Use `const` by default; avoid mutation when practical.
+- Use exhaustive checks (`never`) for union switches.
+- Keep compiler+lint green before completion.
+
+## Reference Map
+
+- Compiler/strict baseline: `references/01-compiler-and-quality-baseline.md`
+- Type system patterns: `references/02-advanced-type-system.md`
+- API/schema/contracts: `references/03-api-and-schema-typing.md`
+- Framework-specific patterns: `references/04-framework-playbooks.md`
+- Data/persistence/runtime boundaries: `references/05-data-and-runtime-boundaries.md`
+- Testing strategy: `references/06-testing-types-and-behavior.md`
+- Code review standards: `references/07-code-review-and-standards.md`
+- Source corpus index (downloaded posts): `references/source-corpus-index.md`
+
+## Execution Guidance
+
+- For small fixes: apply minimal patch + enforce local invariants.
+- For medium changes: establish/repair types first, then implementation.
+- For large migrations: convert module-by-module, maintain compatibility adapters, and increase strictness in stages.
+- If runtime/library constraints conflict with strict typing, document trade-offs and isolate unsafe edges.

--- a/docs/skills/typescript-ultimate/references/01-compiler-and-quality-baseline.md
+++ b/docs/skills/typescript-ultimate/references/01-compiler-and-quality-baseline.md
@@ -1,0 +1,27 @@
+# 01) Compiler and Quality Baseline
+
+## tsconfig baseline (production)
+
+- `strict: true`
+- `noUncheckedIndexedAccess: true`
+- `exactOptionalPropertyTypes: true`
+- `noImplicitOverride: true`
+- `noFallthroughCasesInSwitch: true`
+- `useUnknownInCatchVariables: true`
+- `verbatimModuleSyntax: true`
+- `isolatedModules: true`
+- `noEmit: true` (for CI/typecheck stage)
+
+## Project policy
+
+- Type-only imports: `import type { X } from '...'`
+- Avoid `any`; require explicit justification for unavoidable usage.
+- Avoid broad `as` casting; prefer source typing + guards.
+- Require explicit public/protected/private on class members when classes are used.
+
+## PR gate
+
+1. `tsc --noEmit`
+2. lint pass
+3. test pass
+4. no unresolved `TODO(any)` in changed files

--- a/docs/skills/typescript-ultimate/references/02-advanced-type-system.md
+++ b/docs/skills/typescript-ultimate/references/02-advanced-type-system.md
@@ -1,0 +1,39 @@
+# 02) Advanced Type System
+
+## Use in this order
+
+1. Clear domain model (interfaces/type aliases)
+2. Union + discriminant for variants
+3. Generics for reuse
+4. Conditional/mapped/template-literal helpers for DRY
+5. Recursive/deep types only when necessary
+
+## Core patterns
+
+- Generics with constraints (`<T extends Constraint>`)
+- Conditional types with `infer`
+- Mapped types for transformations (`Readonly`, `Partial`, keyed remap)
+- Template literal types for event keys/paths
+- Utility types (`Pick`, `Omit`, `Extract`, `Exclude`, `Record`, `NonNullable`)
+
+## Reliability patterns
+
+- Exhaustive switch:
+
+```ts
+const _never: never = value;
+```
+
+- Branded IDs:
+
+```ts
+type UserId = string & { readonly __brand: 'UserId' };
+```
+
+- Deep readonly / deep partial only at boundaries (avoid overuse in internals).
+
+## Anti-patterns
+
+- Over-engineered type gymnastics that reduce readability.
+- Type-level recursion without depth controls.
+- Assertions instead of narrowing.

--- a/docs/skills/typescript-ultimate/references/03-api-and-schema-typing.md
+++ b/docs/skills/typescript-ultimate/references/03-api-and-schema-typing.md
@@ -1,0 +1,37 @@
+# 03) API and Schema Typing
+
+## Contract-first
+
+- Define endpoint contracts in one place (path, method, params, body, response, errors).
+- Generate types from OpenAPI when available; avoid manual drift.
+- Keep transport DTO and domain model separated.
+
+## Boundary flow
+
+1. Input arrives as `unknown`
+2. Validate/parse into DTO
+3. Map DTO -> domain type
+4. Execute logic
+5. Map domain -> response DTO
+
+## Request typing pattern
+
+- Route/method keyed config type.
+- Helper types for params/body/response extraction.
+- Strongly typed client wrappers.
+
+## Error model
+
+- Use discriminated unions for API errors:
+  - validation
+  - auth
+  - permission
+  - not-found
+  - conflict
+  - internal
+
+## OpenAPI guidance
+
+- Keep generated types isolated in one module.
+- Never edit generated files directly.
+- Add small handwritten adapters around generated types.

--- a/docs/skills/typescript-ultimate/references/04-framework-playbooks.md
+++ b/docs/skills/typescript-ultimate/references/04-framework-playbooks.md
@@ -1,0 +1,27 @@
+# 04) Framework Playbooks
+
+## React / Next.js
+
+- Type props and component contracts explicitly.
+- Prefer derived types from source-of-truth schemas.
+- Model async UI state with discriminated unions.
+- Keep server/client boundary types explicit in Next.
+
+## Node / Express / Fastify / Nest
+
+- Type request params/body/query and response shape.
+- Avoid untyped middleware side effects.
+- Centralize shared request-context types.
+- In Nest, keep DTO, entity, and domain types distinct.
+
+## Testing frameworks (Jest/E2E)
+
+- Type fixtures/factories.
+- Avoid `as` in tests except controlled setup boundaries.
+- Validate serialization/deserialization behavior.
+
+## Deno / React Native / Vue/Nuxt TS
+
+- Respect platform module resolution and tsconfig constraints.
+- Keep env/platform typings in dedicated modules.
+- Add explicit ambient declarations only when unavoidable.

--- a/docs/skills/typescript-ultimate/references/05-data-and-runtime-boundaries.md
+++ b/docs/skills/typescript-ultimate/references/05-data-and-runtime-boundaries.md
@@ -1,0 +1,25 @@
+# 05) Data and Runtime Boundaries
+
+## DB/ORM (TypeORM and similar)
+
+- Separate persistence types from domain types.
+- Never leak ORM entity types across service boundaries.
+- Use repository return types that match domain contracts.
+
+## JSON and external payloads
+
+- Treat parsed JSON as `unknown`.
+- Parse -> validate -> narrow.
+- Use `Record<string, unknown>` instead of `any` for generic JSON objects.
+
+## Config and env
+
+- Define typed config schema once.
+- Fail fast at startup on invalid config.
+- Expose readonly config object to app modules.
+
+## Runtime safety
+
+- Use nullish coalescing (`??`) over `||` for defaults.
+- Use optional chaining (`?.`) where absence is expected.
+- Guard all edge IO points (network, file, message queues, webhooks).

--- a/docs/skills/typescript-ultimate/references/06-testing-types-and-behavior.md
+++ b/docs/skills/typescript-ultimate/references/06-testing-types-and-behavior.md
@@ -1,0 +1,27 @@
+# 06) Testing Types and Behavior
+
+## Minimum quality set
+
+1. Typecheck (`tsc --noEmit`)
+2. Runtime unit/integration tests
+3. API contract tests (request/response typing + validation behavior)
+4. E2E tests for critical flows
+
+## Type testing techniques
+
+- Compile-time assertions for expected inference.
+- Exhaustiveness tests for union branches.
+- Negative tests for invalid assignments (expect compile failure).
+
+## Runtime testing focus
+
+- Boundary parsing failures
+- Null/undefined edge cases
+- Serialization round-trips
+- Backward compatibility in migrated modules
+
+## Refactor safety
+
+- Snapshot only for stable structural outputs.
+- Prefer semantic assertions over broad snapshots.
+- Keep typed test factories to reduce fixture drift.

--- a/docs/skills/typescript-ultimate/references/07-code-review-and-standards.md
+++ b/docs/skills/typescript-ultimate/references/07-code-review-and-standards.md
@@ -1,0 +1,28 @@
+# 07) Code Review and Standards
+
+## Review checklist
+
+- [ ] No unsafe `any` in changed core logic
+- [ ] Assertions (`as`) minimized and justified
+- [ ] Imports sorted; type-only imports used
+- [ ] Return types and public API types are clear
+- [ ] Union handling is exhaustive
+- [ ] Nullability handled intentionally
+- [ ] Error paths typed and explicit
+- [ ] Mutable shared state avoided or isolated
+- [ ] Tests cover behavior and type contract
+
+## Style heuristics
+
+- Prefer simple, obvious code over clever abstractions.
+- Prefer early returns over deep nesting.
+- Prefer functions over static-only classes.
+- Keep one responsibility per module.
+- Keep names explicit and domain-oriented.
+
+## Forbidden unless justified
+
+- Throwing non-Error values
+- Silent `catch` blocks
+- Hidden implicit `any`
+- Broad `eslint-disable` across files

--- a/docs/skills/typescript-ultimate/references/source-corpus-index.md
+++ b/docs/skills/typescript-ultimate/references/source-corpus-index.md
@@ -1,0 +1,56 @@
+# Source Corpus Index
+
+Collected from https://skills.sh/?q=Type (top visible Type-related results at collection time).
+Downloaded raw HTML + extracted text are stored under `research/typescript-skills/raw` and `research/typescript-skills/text`.
+
+## Skills included (50)
+1. https://skills.sh/wshobson/agents/typescript-advanced-types
+2. https://skills.sh/softaworks/agent-toolkit/openapi-to-typescript
+3. https://skills.sh/sickn33/antigravity-awesome-skills/typescript-expert
+4. https://skills.sh/wshobson/agents/python-type-safety
+5. https://skills.sh/dotneet/claude-code-marketplace/typescript-react-reviewer
+6. https://skills.sh/bmad-labs/skills/typescript-e2e-testing
+7. https://skills.sh/openrouterteam/agent-skills/openrouter-typescript-sdk
+8. https://skills.sh/pproenca/dot-skills/typescript
+9. https://skills.sh/jeffallan/claude-skills/typescript-pro
+10. https://skills.sh/giuseppe-trisciuoglio/developer-kit/typescript-docs
+11. https://skills.sh/lobehub/lobehub/typescript
+12. https://skills.sh/0xbigboss/claude-code/typescript-best-practices
+13. https://skills.sh/mindrally/skills/nextjs-react-typescript
+14. https://skills.sh/jezweb/claude-skills/typescript-mcp
+15. https://skills.sh/zhanghandong/rust-skills/m05-type-driven
+16. https://skills.sh/bobmatnyc/claude-mpm-skills/trpc-type-safety
+17. https://skills.sh/typefully/agent-skills/typefully
+18. https://skills.sh/davila7/claude-code-templates/typescript-expert
+19. https://skills.sh/bobmatnyc/claude-mpm-skills/nodejs-backend-typescript
+20. https://skills.sh/bobmatnyc/claude-mpm-skills/jest-typescript
+21. https://skills.sh/mindrally/skills/typeorm
+22. https://skills.sh/lobehub/lobe-chat/typescript
+23. https://skills.sh/skillcreatorai/ai-agent-skills/javascript-typescript
+24. https://skills.sh/metabase/metabase/typescript-review
+25. https://skills.sh/metabase/metabase/typescript-write
+26. https://skills.sh/mindrally/skills/expo-react-native-typescript
+27. https://skills.sh/mindrally/skills/nextjs-typescript-tailwindcss-supabase
+28. https://skills.sh/sickn33/antigravity-awesome-skills/typescript-pro
+29. https://skills.sh/davila7/claude-code-templates/openapi-to-typescript
+30. https://skills.sh/mindrally/skills/optimized-nextjs-typescript
+31. https://skills.sh/sickn33/antigravity-awesome-skills/typescript-advanced-types
+32. https://skills.sh/martinholovsky/claude-skills-generator/typescript-expert
+33. https://skills.sh/jwynia/agent-skills/typescript-best-practices
+34. https://skills.sh/cexll/myclaude/prototype-prompt-generator
+35. https://skills.sh/rivet-dev/skills/rivetkit-typescript
+36. https://skills.sh/makfly/superpowers-symfony/symfony:form-types-validation
+37. https://skills.sh/mindrally/skills/nuxtjs-vue-typescript
+38. https://skills.sh/alinaqi/claude-bootstrap/typescript
+39. https://skills.sh/dalestudy/skills/typescript
+40. https://skills.sh/mindrally/skills/express-typescript
+41. https://skills.sh/mindrally/skills/nestjs-clean-typescript
+42. https://skills.sh/jgeurts/eslint-config-decent/enforcing-typescript-standards
+43. https://skills.sh/mindrally/skills/deno-typescript
+44. https://skills.sh/bobmatnyc/claude-mpm-skills/typescript-core
+45. https://skills.sh/prowler-cloud/prowler/typescript
+46. https://skills.sh/mindrally/skills/vuejs-typescript-best-practices
+47. https://skills.sh/mindrally/skills/fastify-typescript
+48. https://skills.sh/sickn33/antigravity-awesome-skills/javascript-typescript-typescript-scaffold
+49. https://skills.sh/siviter-xyz/dot-agent/typescript
+50. https://skills.sh/asyrafhussin/agent-skills/typescript-react-patterns

--- a/docs/skills/typescript-ultimate/scripts/refresh_corpus.py
+++ b/docs/skills/typescript-ultimate/scripts/refresh_corpus.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Refresh Type-related skill corpus from skills.sh search results.
+Saves raw HTML + text extracts to research/typescript-skills.
+"""
+
+from html.parser import HTMLParser
+from pathlib import Path
+import re
+import urllib.request
+
+BASE = "https://skills.sh"
+QUERY = f"{BASE}/?q=Type"
+OUT = Path("research/typescript-skills")
+
+
+class MainText(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.in_main = False
+        self.skip = 0
+        self.parts = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "main":
+            self.in_main = True
+        if self.in_main and tag in ("script", "style", "noscript", "svg"):
+            self.skip += 1
+        if self.in_main and self.skip == 0 and tag in ("h1", "h2", "h3", "h4", "p", "li", "pre", "code", "br"):
+            self.parts.append("\n")
+
+    def handle_endtag(self, tag):
+        if self.in_main and tag in ("script", "style", "noscript", "svg") and self.skip > 0:
+            self.skip -= 1
+        if tag == "main":
+            self.in_main = False
+
+    def handle_data(self, data):
+        if self.in_main and self.skip == 0:
+            s = data.strip()
+            if s:
+                self.parts.append(s + " ")
+
+    def text(self):
+        txt = "".join(self.parts)
+        return re.sub(r"\n{3,}", "\n\n", txt).strip()
+
+
+def get(url: str) -> str:
+    return urllib.request.urlopen(url, timeout=25).read().decode("utf-8", "ignore")
+
+
+def extract_links(search_html: str):
+    # Extract visible skill links from list items (/owner/repo/skill)
+    links = sorted(set(re.findall(r'href="(/[^"#? ]+)"', search_html)))
+    return [l for l in links if len([p for p in l.split('/') if p]) == 3]
+
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    (OUT / "raw").mkdir(exist_ok=True)
+    (OUT / "text").mkdir(exist_ok=True)
+
+    html = get(QUERY)
+    links = extract_links(html)
+
+    index_lines = []
+    for link in links:
+        url = BASE + link
+        slug = link.strip('/').replace('/', '__').replace(':', '-')
+        try:
+            page = get(url)
+        except Exception:
+            continue
+        (OUT / "raw" / f"{slug}.html").write_text(page)
+
+        p = MainText()
+        p.feed(page)
+        txt = p.text()
+        if len(txt) < 200:
+            txt = re.sub(r"<script[\s\S]*?</script>", " ", page)
+            txt = re.sub(r"<style[\s\S]*?</style>", " ", txt)
+            txt = re.sub(r"<[^>]+>", " ", txt)
+            txt = re.sub(r"\s+", " ", txt).strip()
+
+        (OUT / "text" / f"{slug}.txt").write_text(txt)
+        index_lines.append(f"{link}\t{len(txt)}")
+
+    (OUT / "index.tsv").write_text("\n".join(index_lines) + "\n")
+    print(f"saved {len(index_lines)} skill pages")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a full TypeScript Ultimate skill pack under `docs/skills/typescript-ultimate`
- include workflow, mandatory rules, and 7 domain references + corpus index
- add `docs/skills/README.md` and link skills section from `docs/README.md`

## Why
- user requested integrating the compiled TypeScript skill synthesis directly into the Mandu framework repo

## Scope
- docs-only change (no runtime code changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive TypeScript skill documentation covering advanced type system practices, API and schema typing, framework-specific playbooks for popular frameworks, runtime safety guidelines, testing strategies, and code review standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->