### PR TITLE
fix: resolve 7 issues from GitHub issue triage

### DIFF
--- a/demo/ai-chat/.gitignore
+++ b/demo/ai-chat/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.mandu/
+mandu-report.json
+*.log
+.env
+.env.local
+.env.*.local

--- a/demo/ate-integration-test/.gitignore
+++ b/demo/ate-integration-test/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.mandu/
+mandu-report.json
+*.log
+.env
+.env.local
+.env.*.local

--- a/demo/island-first/.gitignore
+++ b/demo/island-first/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.mandu/
+mandu-report.json
+*.log
+.env
+.env.local
+.env.*.local

--- a/demo/todo-list-mandu/.gitignore
+++ b/demo/todo-list-mandu/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.mandu/
+mandu-report.json
+*.log
+.env
+.env.local
+.env.*.local

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -196,7 +196,9 @@ export async function dev(options: DevOptions = {}): Promise<void> {
   });
 
   if (port !== desiredPort) {
-    console.warn(`⚠️  Port ${desiredPort} is in use. Using ${port} instead.`);
+    console.warn(`⚠️  Port ${desiredPort} is in use.`);
+    console.warn(`    Dev server:    http://localhost:${port}`);
+    console.warn(`    HMR WebSocket: ws://localhost:${port + HMR_OFFSET}`);
   }
 
   // HMR 서버 시작 (클라이언트 슬롯이 있는 경우)

--- a/packages/cli/templates/default/package.json
+++ b/packages/cli/templates/default/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "mandu dev",
+    "dev:safe": "mandu lock && mandu dev",
     "build": "mandu build",
     "start": "mandu start",
     "check": "mandu check",

--- a/packages/core/src/bundler/css.ts
+++ b/packages/core/src/bundler/css.ts
@@ -259,8 +259,20 @@ export async function startCSSWatch(options: CSSBuildOptions): Promise<CSSWatche
 
       const text = decoder.decode(value).trim();
       if (text) {
-        // bash_profile 경고는 무시
+        // 환경 경고 무시
         if (text.includes(".bash_profile") || text.includes("$'\\377")) {
+          continue;
+        }
+        // Tailwind CLI 정상 진행 메시지는 info 레벨로 처리
+        // (패키지 해석, 다운로드, 잠금 파일 등은 정상 동작)
+        if (
+          text.includes("Resolving dependencies") ||
+          text.includes("Resolved, downloaded") ||
+          text.includes("Saved lockfile") ||
+          text.includes("≈ tailwindcss") ||
+          text.match(/^v?\d+\.\d+\.\d+/) // 버전 출력
+        ) {
+          if (text) console.log(`   ℹ️  CSS: ${text}`);
           continue;
         }
         console.error(`   ❌ CSS Error: ${text}`);

--- a/packages/core/src/bundler/dev.ts
+++ b/packages/core/src/bundler/dev.ts
@@ -533,7 +533,19 @@ export function generateHMRClientScript(port: number): string {
     const overlay = document.createElement('div');
     overlay.id = 'mandu-hmr-error';
     overlay.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.9);color:#ff6b6b;font-family:monospace;padding:40px;z-index:99999;overflow:auto;';
-    overlay.innerHTML = '<h2 style="color:#ff6b6b;margin:0 0 20px;">🔥 Build Error</h2><pre style="white-space:pre-wrap;word-break:break-all;">' + (message || 'Unknown error') + '</pre><button onclick="this.parentElement.remove()" style="position:fixed;top:20px;right:20px;background:#333;color:#fff;border:none;padding:10px 20px;cursor:pointer;">Close</button>';
+    const h2 = document.createElement('h2');
+    h2.style.cssText = 'color:#ff6b6b;margin:0 0 20px;';
+    h2.textContent = '🔥 Build Error';
+    const pre = document.createElement('pre');
+    pre.style.cssText = 'white-space:pre-wrap;word-break:break-all;';
+    pre.textContent = message || 'Unknown error';
+    const btn = document.createElement('button');
+    btn.style.cssText = 'position:fixed;top:20px;right:20px;background:#333;color:#fff;border:none;padding:10px 20px;cursor:pointer;';
+    btn.textContent = 'Close';
+    btn.onclick = function() { overlay.remove(); };
+    overlay.appendChild(h2);
+    overlay.appendChild(pre);
+    overlay.appendChild(btn);
     document.body.appendChild(overlay);
   }
 

--- a/packages/core/src/runtime/escape.ts
+++ b/packages/core/src/runtime/escape.ts
@@ -1,4 +1,16 @@
 /**
+ * HTML 텍스트 콘텐츠 이스케이프
+ * <title>, <p> 등 텍스트 노드에 들어갈 문자열을 안전하게 처리.
+ * 속성값과 달리 " ' 는 이스케이프 불필요.
+ */
+export function escapeHtmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
  * HTML 속성값 이스케이프
  * XSS 방지를 위해 HTML 속성값에 들어갈 문자열을 안전하게 처리
  */

--- a/packages/core/src/runtime/ssr.ts
+++ b/packages/core/src/runtime/ssr.ts
@@ -5,7 +5,7 @@ import type { ReactElement } from "react";
 import type { BundleManifest } from "../bundler/types";
 import type { HydrationConfig, HydrationPriority } from "../spec/schema";
 import { PORTS, TIMEOUTS } from "../constants";
-import { escapeHtmlAttr, escapeJsonForInlineScript } from "./escape";
+import { escapeHtmlAttr, escapeHtmlText, escapeJsonForInlineScript } from "./escape";
 import { REACT_INTERNALS_SHIM_SCRIPT } from "./shims";
 
 // Re-export streaming SSR utilities
@@ -243,7 +243,7 @@ export function renderToHTML(element: ReactElement, options: SSROptions = {}): s
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escapeHtmlAttr(title)}</title>
+  <title>${escapeHtmlText(title)}</title>
   ${cssLinkTag}
   ${headTags}
 </head>


### PR DESCRIPTION
- fix(ssr): use escapeHtmlText (not escapeHtmlAttr) for <title> content so quote characters render correctly in browser tab (#112)
- fix(streaming-ssr): add WeakSet to isJSONSerializable to prevent infinite recursion on circular reference objects (#113)
- fix(bundler): fix XSS in dev error overlay — replace innerHTML with safe DOM textContent APIs (#118)
- fix(css): filter Tailwind CLI progress messages from stderr so they are logged as info, not errors (#124)
- fix(dev): show HMR WebSocket port in port-conflict warning (#116)
- fix(template): add dev:safe script to match lockfile warning message (#128)
- fix(demo): add .gitignore to ai-chat, todo-list-mandu, island-first, ate-integration-test demos to prevent node_modules commit (#107)